### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/top-on/optimal-congress/security/code-scanning/2](https://github.com/top-on/optimal-congress/security/code-scanning/2)

In general, fix this by explicitly defining a `permissions` block that grants only the minimal required scopes. For a typical linting/pre-commit workflow that only reads code, `contents: read` is sufficient; broader or write permissions should only be added if a specific step needs them.

For this specific `.github/workflows/pre-commit.yml`, the least-privilege fix is to add a `permissions` block at the workflow root level (between `on:` and `concurrency:` or just after `name:`). This will apply to all jobs (there is only `pre-commit`) unless a job overrides it. Since the shown steps only check out the repository, set up Python, and run pre-commit, they need only read access to repository contents. The change is limited to inserting:

```yaml
permissions:
  contents: read
```

near the top of the file. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
