### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/top-on/optimal-congress/security/code-scanning/1](https://github.com/top-on/optimal-congress/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants the minimum required access to `GITHUB_TOKEN`. For this pytest workflow, the steps only need to read the repository contents to check out the code; they do not push changes, create releases, or modify issues/PRs, so `contents: read` is sufficient.

The best fix is to add a workflow-level `permissions` block near the top of `.github/workflows/pytest.yml`, so that it applies to all jobs (currently just `test`). Concretely, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (e.g., after line 7 or 8) and before `concurrency:`. No imports or additional definitions are required; this is purely a configuration change in the YAML file. This change does not alter the behavior of the existing steps, but it restricts the `GITHUB_TOKEN` to read-only repository contents, addressing the CodeQL warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
